### PR TITLE
Add package cifs-utils

### DIFF
--- a/scripts/configuration.nix
+++ b/scripts/configuration.nix
@@ -48,6 +48,7 @@
     netcat
     nfs-utils
     rsync
+    cifs-utils
   ];
 
   users.users.root = { password = "vagrant"; };


### PR DESCRIPTION
when use qemu tips, and need cifs supported

```shell
Vagrant is currently configured to mount SMB folders with the
`mfsymlink` option enabled. This is equivalent to adding the
following to your Vagrantfile:

  config.vm.synced_folder '/host/path', '/guest/path', type: "smb", mount_options: ['mfsymlink']

This option may be globally disabled with an environment variable:

  VAGRANT_DISABLE_SMBMFSYMLINKS=1
Failed to mount folders in Linux guest. This is usually because
the "vboxsf" file system is not available. Please verify that
the guest additions are properly installed in the guest and
can work properly. The command attempted was:

mount -t cifs -o vers=2.0,credentials=/etc/smb_creds_vgt-ad5f69b25309027237702fe2fb9dd6ac-6ad5fdbcbf2eaa93bd62f92333a2e6e5,uid=1000,gid=994,mfsymlinks,_netdev,nofail //192.168.195.22/vgt-ad5f69b25309027237702fe2fb9dd6ac-6ad5fdbcbf2eaa93bd62f92333a2e6e5 /*****

The error output from the last command was:

mount: /*****: bad option; for several filesystems (e.g. nfs, cifs) you might need a /sbin/mount.<type> helper program.
       dmesg(1) may have more information after failed mount system call.
```